### PR TITLE
Add test script (shell script)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+COPY count.sh /
+RUN chmod u+x /count.sh
+CMD /count.sh

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 * run with `docker-compose up -d`
 * check log with `journalctl  CONTAINER_TAG=ctn1 -u docker.service --since "1 days ago" --reverse`
+The shell script stops after 10000 iterations / log lines. You can also:
 * stop with `docker-compose down`
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,5 @@
 
 * run with `docker-compose up -d`
 * check log with `journalctl  CONTAINER_TAG=ctn1 -u docker.service --since "1 days ago" --reverse`
-The shell script stops after 10000 iterations / log lines. You can also:
+* The shell script stops after 10000 iterations / log lines. You can also:
 * stop with `docker-compose down`
-

--- a/count.sh
+++ b/count.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+count=1
+while [ $count -lt 10000 ] ; do
+	>&2 echo "[$(hostname -s)] [$(date +'%Y-%m-%dT%H:%M:%S')] $count"
+	count=$(expr $count + 1);
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.4'
 
 services:
   ctn1:
-    image: "busybox"
-    command: ["sh", "-c", "while true; do date; done"]
+    build:
+      context: .
     logging:
       driver: journald
       options:


### PR DESCRIPTION
This is an update to the test routine to be able to follow dropped log lines.

The script generates 9999 log entries - each numbered and with timestamp.

Looking at the output from journalctl and counting the lines using `wc -l` can give a good indication of the number of dropped log lines. In my experiments, usually 15 - 25 lines were dropped, most of them at the beginning of the logging process.